### PR TITLE
No Gift Memberships still sends email

### DIFF
--- a/giftmemberships.php
+++ b/giftmemberships.php
@@ -136,7 +136,7 @@ function giftmemberships_civicrm_postProcess($formName, &$form) {
         $contributionId = $form->_contributionID;
         $giverId = $form->_contactID;
         foreach ($submitValues as $key => $value) {
-            if (strpos($key, '_gift-codes') !== false) {
+            if (strpos($key, '_gift-codes') !== false && !empty($value)) {
                 $giftcodes = true;
                 $price = explode("_", $key);
                 $pfid = $price[0];


### PR DESCRIPTION
This is a check to make sure there's actually a value set in the form before creating the codes and preparing the email.  With no value set, the email will still be sent but no codes are listed.
